### PR TITLE
Make appliance URL configurable

### DIFF
--- a/pcf-with-installed-tile/README.md
+++ b/pcf-with-installed-tile/README.md
@@ -37,6 +37,13 @@ Authenticate as the `admin` user for the Conjur instance (or another user who ha
 ## Running the demo
 Our demo script will be modifying Conjur policy to add the application host to a group with access to the application's secrets, so it will need access to Conjur account info. Since we have stored this info in the OSX keyring, we can run the [demo script](bin/start) by calling `./bin/start` (for v4) or `summon -p keyring.py ./bin/start` (for v5).
 
+The demo scripts are configured to work with ["Try Conjur"](https://www.conjur.org/get-started/try-conjur.html)
+by default (`eval.conjur.org`). To use the scripts with a different Conjur instance, set the `APPLIANCE_URL`
+environment variable before running the demo scripts:
+```
+$ export APPLIANCE_URL="{your_appliance_url}"
+```
+
 ### What the script does
 The start-up script clears out your workspace - it deletes any previously deployed `hello-world` apps in the demo space, removes the Conjur service, and removes the demo space.
 

--- a/pcf-with-installed-tile/bin/2-load-secrets-into-conjur
+++ b/pcf-with-installed-tile/bin/2-load-secrets-into-conjur
@@ -8,7 +8,7 @@ then
     -e CONJUR_AUTHN_API_KEY="$API_KEY" \
     -e CONJUR_AUTHN_LOGIN="admin" \
     -e CONJUR_ACCOUNT="$ACCOUNT" \
-    -e CONJUR_APPLIANCE_URL="eval.conjur.org" \
+    -e CONJUR_APPLIANCE_URL="${APPLIANCE_URL:-'https://eval.conjur.org'}" \
     --entrypoint bash cyberark/conjur-cli:5 -c '
       conjur policy load root policy/policy.yml
       conjur policy load root policy/cf_5.yml

--- a/pcf-with-installed-tile/bin/4-privilege-org-space
+++ b/pcf-with-installed-tile/bin/4-privilege-org-space
@@ -19,7 +19,7 @@ then
     -e CONJUR_AUTHN_API_KEY="$API_KEY" \
     -e CONJUR_AUTHN_LOGIN="admin" \
     -e CONJUR_ACCOUNT="$ACCOUNT" \
-    -e CONJUR_APPLIANCE_URL="https://eval.conjur.org" \
+    -e CONJUR_APPLIANCE_URL="${APPLIANCE_URL:-'https://eval.conjur.org'}" \
     -e ORG_LAYER_NAME="$ORG_LAYER_NAME" \
     -e SPACE_LAYER_NAME="$SPACE_LAYER_NAME" \
     --entrypoint bash cyberark/conjur-cli:5 -c '

--- a/pcf-with-installed-tile/bin/6-privilege-app
+++ b/pcf-with-installed-tile/bin/6-privilege-app
@@ -10,7 +10,7 @@ then
     -e CONJUR_AUTHN_API_KEY="$API_KEY" \
     -e CONJUR_AUTHN_LOGIN="admin" \
     -e CONJUR_ACCOUNT="$ACCOUNT" \
-    -e CONJUR_APPLIANCE_URL="eval.conjur.org" \
+    -e CONJUR_APPLIANCE_URL="${APPLIANCE_URL:-'https://eval.conjur.org'}" \
     -e APP_HOST_NAME="$APP_HOST_NAME" \
     --entrypoint bash conjurinc/cli5 -c '
       replace="s~<APP_HOST_NAME>~$APP_HOST_NAME~";

--- a/pcf-with-installed-tile/bin/rotate
+++ b/pcf-with-installed-tile/bin/rotate
@@ -14,7 +14,7 @@ then
     -e CONJUR_AUTHN_API_KEY="$API_KEY" \
     -e CONJUR_AUTHN_LOGIN="admin" \
     -e CONJUR_ACCOUNT="$ACCOUNT" \
-    -e CONJUR_APPLIANCE_URL="eval.conjur.org" \
+    -e CONJUR_APPLIANCE_URL="${APPLIANCE_URL:-'https://eval.conjur.org'}" \
     -e APPEND_STRING="$APPEND_STRING" \
     --entrypoint bash conjurinc/cli5 -c '
       conjur variable values add cf/org/database/username "org database username $APPEND_STRING";


### PR DESCRIPTION
This PR updates the pcf tile demo to make the appliance URL configurable with an environment variable, rather than only allowing a hardcoded value in the scripts.

Connected to #33 