### PR TITLE
Use the release asset for the service broker instead of the source zip

### DIFF
--- a/local/bin/04-install-service-broker
+++ b/local/bin/04-install-service-broker
@@ -2,10 +2,11 @@
 APP_NAME="hello-world"
 
 # get the Conjur service broker, upload to cf, and configure
-curl -L $(curl -s https://api.github.com/repos/cyberark/conjur-service-broker/releases/latest | grep zipball_url | awk '{print $NF}' | sed 's/",*//g') > conjur-service-broker.zip
-unzip conjur-service-broker.zip
-repo_dir=$(ls | grep cyberark-conjur-service-broker)
-mv $repo_dir conjur-service-broker
+curl -L $(curl -s https://api.github.com/repos/cyberark/conjur-service-broker/releases/latest \
+          | grep browser_download_url \
+          | awk '{print $NF}' \
+          | sed 's/",*//g') > conjur-service-broker.zip
+unzip conjur-service-broker.zip -d conjur-service-broker
 
 # push the SB app
 pushd conjur-service-broker


### PR DESCRIPTION
The latest service broker release includes a compiled Go binary for health checking that isn't included in the source zip file alone.

Our local demo is downloading the source zip, rather than the release asset zip, so the health check binary is not present and the service broker deploy fails.

This PR updates the download URL to use the release asset zip instead of the source zip.