### PR TITLE
Upgrade rack to v2.2.3 to close CVE-2020-8184 and CVE-2020-8161

### DIFF
--- a/local/app/Gemfile.lock
+++ b/local/app/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     mustermann (1.0.3)
-    rack (2.0.8)
+    rack (2.2.3)
     rack-protection (2.0.5)
       rack
     sinatra (2.0.5)


### PR DESCRIPTION
Rack version bump to close CVEs that were present but didn't impact us.

Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>