### PR TITLE
Bump dependencies in sample apps

### DIFF
--- a/local/app/Gemfile
+++ b/local/app/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'sinatra', ">= 2.0.2"
-gem 'rack', ">= 2.0.6"
+gem 'sinatra', ">= 2.0.8"
+gem 'rack', ">= 2.2.3"

--- a/local/app/Gemfile.lock
+++ b/local/app/Gemfile.lock
@@ -1,23 +1,25 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    mustermann (1.0.3)
-    rack (2.0.8)
-    rack-protection (2.0.5)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
+    rack (2.2.3)
+    rack-protection (2.0.8.1)
       rack
-    sinatra (2.0.5)
+    ruby2_keywords (0.0.2)
+    sinatra (2.0.8.1)
       mustermann (~> 1.0)
       rack (~> 2.0)
-      rack-protection (= 2.0.5)
+      rack-protection (= 2.0.8.1)
       tilt (~> 2.0)
-    tilt (2.0.9)
+    tilt (2.0.10)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  rack (>= 2.0.6)
-  sinatra (>= 2.0.2)
+  rack (>= 2.2.3)
+  sinatra (>= 2.0.8)
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/tas-with-installed-tile/app/Gemfile
+++ b/tas-with-installed-tile/app/Gemfile
@@ -1,6 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'sinatra', ">= 2.0.2"
-gem 'rack', ">= 2.0.6"
-
-ruby '~> 2.7.0'
+gem 'sinatra', ">= 2.0.8"
+gem 'rack', ">= 2.2.3"

--- a/tas-with-installed-tile/app/Gemfile.lock
+++ b/tas-with-installed-tile/app/Gemfile.lock
@@ -1,23 +1,25 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    mustermann (1.0.3)
-    rack (2.0.8)
-    rack-protection (2.0.5)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
+    rack (2.2.3)
+    rack-protection (2.0.8.1)
       rack
-    sinatra (2.0.5)
+    ruby2_keywords (0.0.2)
+    sinatra (2.0.8.1)
       mustermann (~> 1.0)
       rack (~> 2.0)
-      rack-protection (= 2.0.5)
+      rack-protection (= 2.0.8.1)
       tilt (~> 2.0)
-    tilt (2.0.9)
+    tilt (2.0.10)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  rack (>= 2.0.6)
-  sinatra (>= 2.0.2)
+  rack (>= 2.2.3)
+  sinatra (>= 2.0.8)
 
 BUNDLED WITH
-   1.17.3
+   2.1.4


### PR DESCRIPTION
This PR bumps the dependencies in the sample apps.

~It's a draft for now until the next time we have a TAS environment up, at which time we'll test this again to make sure it works as expected before publishing.~

I've been able to validate that this works with the 1.2.0 tile and a TAS 2.9 foundation.